### PR TITLE
BUGFIX: Fix lrem parameter order

### DIFF
--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -104,8 +104,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * @param string $data The data to be stored
      * @param array $tags Tags to associate with this cache entry. If the backend does not support tags, this option can be ignored.
      * @param integer $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
-     * @throws RuntimeException
      * @return void
+     * @throws RuntimeException
      * @api
      */
     public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
@@ -116,13 +116,13 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
 
         $this->client->multi();
         $lifetime = $lifetime ?? $this->defaultLifetime;
-        if ($lifetime >0) {
+        if ($lifetime > 0) {
             $status = $this->client->set($this->buildKey('entry:' . $entryIdentifier), $this->compress($data), 'ex', $lifetime);
         } else {
             $status = $this->client->set($this->buildKey('entry:' . $entryIdentifier), $this->compress($data));
         }
 
-        $this->client->lRem($this->buildKey('entries'), $entryIdentifier, 0);
+        $this->client->lRem($this->buildKey('entries'), 0, $entryIdentifier);
         $this->client->rPush($this->buildKey('entries'), [$entryIdentifier]);
 
         foreach ($tags as $tag) {
@@ -162,8 +162,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * old entries for the identifier still exist, they are removed as well.
      *
      * @param string $entryIdentifier Specifies the cache entry to remove
-     * @throws RuntimeException
      * @return boolean true if (at least) an entry could be removed or false if no entry was found
+     * @throws RuntimeException
      * @api
      */
     public function remove(string $entryIdentifier): bool
@@ -181,7 +181,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
                 $this->client->sRem($this->buildKey('tag:' . $tag), $entryIdentifier);
             }
             $this->client->del([$this->buildKey('tags:' . $entryIdentifier)]);
-            $this->client->lRem($this->buildKey('entries'), $entryIdentifier, 0);
+            $this->client->lRem($this->buildKey('entries'), 0, $entryIdentifier);
             /** @var array|bool $result */
             $result = $this->client->exec();
         } while ($result === false);
@@ -195,8 +195,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * The flush method will use the EVAL command to flush all entries and tags for this cache
      * in an atomic way.
      *
-     * @throws RuntimeException
      * @return void
+     * @throws RuntimeException
      * @api
      */
     public function flush(): void
@@ -241,8 +241,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * Removes all cache entries of this cache which are tagged by the specified tag.
      *
      * @param string $tag The tag the entries must have
-     * @throws RuntimeException
      * @return integer The number of entries which have been affected by this flush
+     * @throws RuntimeException
      * @api
      */
     public function flushByTag(string $tag): int
@@ -333,8 +333,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      *
      * A frozen backend can only be thawn by calling the flush() method.
      *
-     * @throws RuntimeException
      * @return void
+     * @throws RuntimeException
      */
     public function freeze(): void
     {
@@ -405,7 +405,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     {
         if (is_string($sentinels)) {
             $this->sentinels = explode(',', $sentinels);
-        } elseif(is_array($sentinels)) {
+        } elseif (is_array($sentinels)) {
             $this->sentinels = $sentinels;
         } else {
             throw new \InvalidArgumentException(sprintf('setSentinels(): Invalid type %s, string or array expected', gettype($sentinels)), 1575384806);
@@ -467,7 +467,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         if (empty($value)) {
             return false;
         }
-        return $this->useCompression() ? gzdecode((string) $value) : $value;
+        return $this->useCompression() ? gzdecode((string)$value) : $value;
     }
 
     /**


### PR DESCRIPTION
While PHP redis extension has

`public function lRem($key, $value, $count);`

predis has

`@method int lrem($key, $count, $value);`