### PR TITLE
BUGFIX: Do not pass null key to has

### DIFF
--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -302,7 +302,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     public function key()
     {
         $entryIdentifier = $this->client->lIndex($this->buildKey('entries'), $this->entryCursor);
-        if ($entryIdentifier !== false && !$this->has($entryIdentifier)) {
+
+        if ($entryIdentifier === null || !$this->has($entryIdentifier)) {
             return false;
         }
         return $entryIdentifier;


### PR DESCRIPTION
When iterating over the entries and we reach the end of the entries list,
lIndex retruns null but has() only accepts strings, which fails.