### PR TITLE
TASK: Use scan instead of a list of elements

### DIFF
--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -117,17 +117,17 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         $this->client->multi();
         $lifetime = $lifetime ?? $this->defaultLifetime;
         if ($lifetime >0) {
-            $status = $this->client->set($this->buildKey('entry:' . $entryIdentifier), $this->compress($data), 'ex', $lifetime);
+            $status = $this->client->set($this->getPrefixedIdentifier('entry:' . $entryIdentifier), $this->compress($data), 'ex', $lifetime);
         } else {
-            $status = $this->client->set($this->buildKey('entry:' . $entryIdentifier), $this->compress($data));
+            $status = $this->client->set($this->getPrefixedIdentifier('entry:' . $entryIdentifier), $this->compress($data));
         }
 
-        $this->client->lRem($this->buildKey('entries'), $entryIdentifier, 0);
-        $this->client->rPush($this->buildKey('entries'), [$entryIdentifier]);
+        $this->client->lRem($this->getPrefixedIdentifier('entries'), $entryIdentifier, 0);
+        $this->client->rPush($this->getPrefixedIdentifier('entries'), [$entryIdentifier]);
 
         foreach ($tags as $tag) {
-            $this->client->sAdd($this->buildKey('tag:' . $tag), [$entryIdentifier]);
-            $this->client->sAdd($this->buildKey('tags:' . $entryIdentifier), [$tag]);
+            $this->client->sAdd($this->getPrefixedIdentifier('tag:' . $tag), [$entryIdentifier]);
+            $this->client->sAdd($this->getPrefixedIdentifier('tags:' . $entryIdentifier), [$tag]);
         }
         $this->client->exec();
     }
@@ -141,7 +141,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     public function get(string $entryIdentifier)
     {
-        return $this->decompress($this->client->get($this->buildKey('entry:' . $entryIdentifier)));
+        return $this->decompress($this->client->get($this->getPrefixedIdentifier('entry:' . $entryIdentifier)));
     }
 
     /**
@@ -153,7 +153,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     public function has(string $entryIdentifier): bool
     {
-        return (bool)$this->client->exists($this->buildKey('entry:' . $entryIdentifier));
+        return (bool)$this->client->exists($this->getPrefixedIdentifier('entry:' . $entryIdentifier));
     }
 
     /**
@@ -172,16 +172,16 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             throw new RuntimeException(sprintf('Cannot remove cache entry because the backend of cache "%s" is frozen.', $this->cacheIdentifier), 1323344192);
         }
         do {
-            $tagsKey = $this->buildKey('tags:' . $entryIdentifier);
+            $tagsKey = $this->getPrefixedIdentifier('tags:' . $entryIdentifier);
             $this->client->watch($tagsKey);
             $tags = $this->client->sMembers($tagsKey);
             $this->client->multi();
-            $this->client->del([$this->buildKey('entry:' . $entryIdentifier)]);
+            $this->client->del([$this->getPrefixedIdentifier('entry:' . $entryIdentifier)]);
             foreach ($tags as $tag) {
-                $this->client->sRem($this->buildKey('tag:' . $tag), $entryIdentifier);
+                $this->client->sRem($this->getPrefixedIdentifier('tag:' . $tag), $entryIdentifier);
             }
-            $this->client->del([$this->buildKey('tags:' . $entryIdentifier)]);
-            $this->client->lRem($this->buildKey('entries'), $entryIdentifier, 0);
+            $this->client->del([$this->getPrefixedIdentifier('tags:' . $entryIdentifier)]);
+            $this->client->lRem($this->getPrefixedIdentifier('entries'), $entryIdentifier, 0);
             /** @var array|bool $result */
             $result = $this->client->exec();
         } while ($result === false);
@@ -214,7 +214,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         redis.call('DEL', KEYS[1])
         redis.call('DEL', KEYS[2])
         ";
-        $this->client->eval($script, 2, $this->buildKey('entries'), $this->buildKey('frozen'), $this->buildKey(''));
+        $this->client->eval($script, 2, $this->getPrefixedIdentifier('entries'), $this->getPrefixedIdentifier('frozen'), $this->getPrefixedIdentifier(''));
         $this->frozen = null;
     }
 
@@ -226,15 +226,6 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     public function collectGarbage(): void
     {
-    }
-
-    /**
-     * @param string $identifier
-     * @return string
-     */
-    private function buildKey(string $identifier): string
-    {
-        return $this->cacheIdentifier . ':' . $identifier;
     }
 
     /**
@@ -264,7 +255,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         end
         return #entries
         ";
-        return $this->client->eval($script, 2, $this->buildKey('tag:' . $tag), $this->buildKey('entries'), $this->buildKey(''));
+        return $this->client->eval($script, 2, $this->getPrefixedIdentifier('tag:' . $tag), $this->getPrefixedIdentifier('entries'), $this->getPrefixedIdentifier(''));
     }
 
     /**
@@ -277,7 +268,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     public function findIdentifiersByTag(string $tag): array
     {
-        return $this->client->sMembers($this->buildKey('tag:' . $tag));
+        return $this->client->sMembers($this->getPrefixedIdentifier('tag:' . $tag));
     }
 
     /**
@@ -301,7 +292,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     public function key()
     {
-        $entryIdentifier = $this->client->lIndex($this->buildKey('entries'), $this->entryCursor);
+        $entryIdentifier = $this->client->lIndex($this->getPrefixedIdentifier('entries'), $this->entryCursor);
         if ($entryIdentifier !== false && !$this->has($entryIdentifier)) {
             return false;
         }
@@ -342,14 +333,14 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
             throw new RuntimeException(sprintf('Cannot add or modify cache entry because the backend of cache "%s" is frozen.', $this->cacheIdentifier), 1574777766);
         }
         do {
-            $entriesKey = $this->buildKey('entries');
+            $entriesKey = $this->getPrefixedIdentifier('entries');
             $this->client->watch($entriesKey);
             $entries = $this->client->lRange($entriesKey, 0, -1);
             $this->client->multi();
             foreach ($entries as $entryIdentifier) {
-                $this->client->persist($this->buildKey('entry:' . $entryIdentifier));
+                $this->client->persist($this->getPrefixedIdentifier('entry:' . $entryIdentifier));
             }
-            $this->client->set($this->buildKey('frozen'), '1');
+            $this->client->set($this->getPrefixedIdentifier('frozen'), '1');
             /** @var array|bool $result */
             $result = $this->client->exec();
         } while ($result === false);
@@ -364,7 +355,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     public function isFrozen(): bool
     {
         if (null === $this->frozen) {
-            $this->frozen = (bool)$this->client->exists($this->buildKey('frozen'));
+            $this->frozen = (bool)$this->client->exists($this->getPrefixedIdentifier('frozen'));
         }
         return $this->frozen;
     }

--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -302,7 +302,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     public function key()
     {
         $entryIdentifier = $this->client->lIndex($this->buildKey('entries'), $this->entryCursor);
-        if ($entryIdentifier !== false && !$this->has($entryIdentifier)) {
+
+        if ($entryIdentifier === null || !$this->has($entryIdentifier)) {
             return false;
         }
         return $entryIdentifier;

--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -292,7 +292,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      */
     public function key()
     {
-        $entryIdentifier = $this->client->lIndex($this->buildKey('entries'), $this->entryCursor);
+        $entryIdentifier = $this->client->lIndex($this->getPrefixedIdentifier('entries'), $this->entryCursor);
 
         if ($entryIdentifier === null || !$this->has($entryIdentifier)) {
             return false;

--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -104,8 +104,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * @param string $data The data to be stored
      * @param array $tags Tags to associate with this cache entry. If the backend does not support tags, this option can be ignored.
      * @param integer $lifetime Lifetime of this cache entry in seconds. If NULL is specified, the default lifetime is used. "0" means unlimited lifetime.
-     * @throws RuntimeException
      * @return void
+     * @throws RuntimeException
      * @api
      */
     public function set(string $entryIdentifier, string $data, array $tags = [], int $lifetime = null): void
@@ -116,13 +116,13 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
 
         $this->client->multi();
         $lifetime = $lifetime ?? $this->defaultLifetime;
-        if ($lifetime >0) {
+        if ($lifetime > 0) {
             $status = $this->client->set($this->buildKey('entry:' . $entryIdentifier), $this->compress($data), 'ex', $lifetime);
         } else {
             $status = $this->client->set($this->buildKey('entry:' . $entryIdentifier), $this->compress($data));
         }
 
-        $this->client->lRem($this->buildKey('entries'), $entryIdentifier, 0);
+        $this->client->lRem($this->buildKey('entries'), 0, $entryIdentifier);
         $this->client->rPush($this->buildKey('entries'), [$entryIdentifier]);
 
         foreach ($tags as $tag) {
@@ -162,8 +162,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * old entries for the identifier still exist, they are removed as well.
      *
      * @param string $entryIdentifier Specifies the cache entry to remove
-     * @throws RuntimeException
      * @return boolean true if (at least) an entry could be removed or false if no entry was found
+     * @throws RuntimeException
      * @api
      */
     public function remove(string $entryIdentifier): bool
@@ -181,7 +181,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
                 $this->client->sRem($this->buildKey('tag:' . $tag), $entryIdentifier);
             }
             $this->client->del([$this->buildKey('tags:' . $entryIdentifier)]);
-            $this->client->lRem($this->buildKey('entries'), $entryIdentifier, 0);
+            $this->client->lRem($this->buildKey('entries'), 0, $entryIdentifier);
             /** @var array|bool $result */
             $result = $this->client->exec();
         } while ($result === false);
@@ -195,8 +195,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * The flush method will use the EVAL command to flush all entries and tags for this cache
      * in an atomic way.
      *
-     * @throws RuntimeException
      * @return void
+     * @throws RuntimeException
      * @api
      */
     public function flush(): void
@@ -241,8 +241,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * Removes all cache entries of this cache which are tagged by the specified tag.
      *
      * @param string $tag The tag the entries must have
-     * @throws RuntimeException
      * @return integer The number of entries which have been affected by this flush
+     * @throws RuntimeException
      * @api
      */
     public function flushByTag(string $tag): int
@@ -333,8 +333,8 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      *
      * A frozen backend can only be thawn by calling the flush() method.
      *
-     * @throws RuntimeException
      * @return void
+     * @throws RuntimeException
      */
     public function freeze(): void
     {
@@ -405,7 +405,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
     {
         if (is_string($sentinels)) {
             $this->sentinels = explode(',', $sentinels);
-        } elseif(is_array($sentinels)) {
+        } elseif (is_array($sentinels)) {
             $this->sentinels = $sentinels;
         } else {
             throw new \InvalidArgumentException(sprintf('setSentinels(): Invalid type %s, string or array expected', gettype($sentinels)), 1575384806);
@@ -467,7 +467,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
         if (empty($value)) {
             return false;
         }
-        return $this->useCompression() ? gzdecode((string) $value) : $value;
+        return $this->useCompression() ? gzdecode((string)$value) : $value;
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Flow_Mvc_Routing_Resolve:
 Note that "service" is the name of your Redis cluster (which is "mymaster" in most default
 configurations).
 
+## Tests
+
+You can adjust the host used in the functional tests using the environmenr variable `REDIS_HOST`;
+
 ## Credits
 
 This cache backend was developed by Robert Lemke of Flownative, based on the Neos Flow Redis Backend,

--- a/Tests/Functional/RedisBackendTest.php
+++ b/Tests/Functional/RedisBackendTest.php
@@ -1,0 +1,255 @@
+<?php
+declare(strict_types=1);
+
+namespace Flownative\RedisSentinel\Tests\Unit;
+
+include_once(__DIR__ . '/../BaseTestCase.php');
+
+/*
+ * This file is part of the Neos.Cache package.
+ * The tests base on Neos\Cache\Tests\Functional\Backend\RedisBackendTest of neos/cache
+ *
+ *
+ * (c) Contributors of the Neos Project - www.neos.io
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Neos\Cache\Backend\RedisBackend;
+use Neos\Cache\EnvironmentConfiguration;
+use Neos\Cache\Tests\BaseTestCase;
+use Neos\Cache\Frontend\FrontendInterface;
+
+/**
+ * Testcase for the redis cache backend
+ *
+ * These tests use an actual Redis instance and will place and remove keys in db 0!
+ * Since all keys have the 'TestCache:' prefix, running the tests should have
+ * no side effects on non-related cache entries.
+ *
+ * Tests require Redis listening on 127.0.0.1:6379.
+ *
+ * @requires extension redis
+ */
+class RedisBackendTest extends BaseTestCase
+{
+    /**
+     * @var RedisBackend
+     */
+    private $backend;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|FrontendInterface
+     */
+    private $cache;
+
+    /**
+     * Set up test case
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        $redisHost = getenv('REDIS_HOST') !== false ? getenv('REDIS_HOST') : '127.0.0.1';
+
+        try {
+            if (!@fsockopen($redisHost, 6379)) {
+                $this->markTestSkipped('redis server not reachable');
+            }
+        } catch (\Exception $e) {
+            $this->markTestSkipped('redis server not reachable');
+        }
+        $this->backend = new RedisBackend(
+            new EnvironmentConfiguration('Redis a wonderful color Testing', '/some/path', PHP_MAXPATHLEN),
+            ['hostname' => $redisHost, 'database' => 0]
+        );
+        $this->cache = $this->createMock(FrontendInterface::class);
+        $this->cache->expects(self::any())->method('getIdentifier')->will(self::returnValue('TestCache'));
+        $this->backend->setCache($this->cache);
+        $this->backend->flush();
+    }
+
+    /**
+     * Tear down test case
+     *
+     * @return void
+     */
+    protected function tearDown(): void
+    {
+        if ($this->backend instanceof RedisBackend) {
+            $this->backend->flush();
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function setAddsCacheEntry()
+    {
+        $this->backend->set('some_entry', 'foo');
+        self::assertEquals('foo', $this->backend->get('some_entry'));
+    }
+
+    /**
+     * @test
+     */
+    public function setAddsTags()
+    {
+        $this->backend->set('some_entry', 'foo', ['tag1', 'tag2']);
+        $this->backend->set('some_other_entry', 'foo', ['tag2', 'tag3']);
+
+        self::assertEquals(['some_entry'], $this->backend->findIdentifiersByTag('tag1'));
+        $expected = ['some_entry', 'some_other_entry'];
+        $actual = $this->backend->findIdentifiersByTag('tag2');
+
+        // since Redis does not garantuee the order of values in sets, manually sort the array for comparison
+        natsort($actual);
+        $actual = array_values($actual);
+
+        self::assertEquals($expected, $actual);
+        self::assertEquals(['some_other_entry'], $this->backend->findIdentifiersByTag('tag3'));
+    }
+
+    /**
+     * @test
+     */
+    public function setDoesNotAddMultipleEntries()
+    {
+        $this->backend->set('some_entry', 'foo');
+        $this->backend->set('some_entry', 'bar');
+
+        $entryIdentifiers = [];
+        foreach ($this->backend as $entryIdentifier => $entryValue) {
+            $entryIdentifiers[] = $entryIdentifier;
+        }
+
+        self::assertEquals(['some_entry'], $entryIdentifiers);
+    }
+
+    /**
+     * @test
+     */
+    public function cacheIsIterable()
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $this->backend->set('entry_' . $i, 'foo');
+        }
+        $actualEntries = [];
+        foreach ($this->backend as $key => $value) {
+            $actualEntries[] = $key;
+        }
+
+        self::assertCount(100, $actualEntries);
+
+        for ($i = 0; $i < 100; $i++) {
+            self::assertContains('entry_' . $i, $actualEntries);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function freezeFreezesTheCache()
+    {
+        self::assertFalse($this->backend->isFrozen());
+        for ($i = 0; $i < 10; $i++) {
+            $this->backend->set('entry_' . $i, 'foo');
+        }
+        $this->backend->freeze();
+        self::assertTrue($this->backend->isFrozen());
+    }
+
+    /**
+     * @test
+     */
+    public function flushByTagFlushesEntryByTag()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->backend->set('entry_' . $i, 'foo', ['tag1', 'tag2']);
+        }
+        for ($i = 10; $i < 20; $i++) {
+            $this->backend->set('entry_' . $i, 'foo', ['tag2']);
+        }
+        self::assertCount(10, $this->backend->findIdentifiersByTag('tag1'));
+        self::assertCount(20, $this->backend->findIdentifiersByTag('tag2'));
+
+        $count = $this->backend->flushByTag('tag1');
+        self::assertEquals(10, $count, 'flushByTag returns amount of flushed entries');
+        self::assertCount(0, $this->backend->findIdentifiersByTag('tag1'));
+        self::assertCount(10, $this->backend->findIdentifiersByTag('tag2'));
+    }
+
+    /**
+     * @test
+     */
+    public function flushByTagRemovesEntries()
+    {
+        $this->backend->set('some_entry', 'foo', ['tag1', 'tag2']);
+
+        $this->backend->flushByTag('tag1');
+
+        $entryIdentifiers = [];
+        foreach ($this->backend as $entryIdentifier => $entryValue) {
+            $entryIdentifiers[] = $entryIdentifier;
+        }
+
+        self::assertEquals([], $entryIdentifiers);
+    }
+
+    /**
+     * @test
+     */
+    public function flushFlushesCache()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->backend->set('entry_' . $i, 'foo', ['tag1']);
+        }
+        self::assertTrue($this->backend->has('entry_5'));
+        $this->backend->flush();
+        self::assertFalse($this->backend->has('entry_5'));
+    }
+
+    /**
+     * @test
+     */
+    public function removeRemovesEntryFromCache()
+    {
+        for ($i = 0; $i < 10; $i++) {
+            $this->backend->set('entry_' . $i, 'foo', ['tag1']);
+        }
+        self::assertCount(10, $this->backend->findIdentifiersByTag('tag1'));
+        self::assertEquals('foo', $this->backend->get('entry_1'));
+        $actualEntries = [];
+        foreach ($this->backend as $key => $value) {
+            $actualEntries[] = $key;
+        }
+        self::assertCount(10, $actualEntries);
+
+        $this->backend->remove('entry_3');
+        self::assertCount(9, $this->backend->findIdentifiersByTag('tag1'));
+        self::assertFalse($this->backend->get('entry_3'));
+        $actualEntries = [];
+        foreach ($this->backend as $key => $value) {
+            $actualEntries[] = $key;
+        }
+        self::assertCount(9, $actualEntries);
+    }
+
+    /**
+     * @test
+     */
+    public function expiredEntriesAreSkippedWhenIterating()
+    {
+        $this->backend->set('entry1', 'foo', [], 1);
+        sleep(2);
+        self::assertFalse($this->backend->has('entry1'));
+
+        $actualEntries = [];
+        foreach ($this->backend as $key => $value) {
+            $actualEntries[] = $key;
+        }
+        self::assertEmpty($actualEntries, 'Entries should be empty');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "email": "support@flownative.com"
     },
     "require": {
-        "neos/cache": "5.* || 6.* || 7.*",
+        "neos/cache": "> 6.3 || 7.*",
         "ext-zlib": "*",
         "predis/predis": "^1.1"
     },


### PR DESCRIPTION
This Uses SCAN (https://redis.io/commands/scan) to iterate over the keyspace
instead of using a big entries list. This should make flush() (and other operations) a lot faster.

It also uses `Predis\Collection\Iterator\Keyspace` to iterate over the entries.

For review: Please merge the other PRs first or cherry-pick the latest commit.