### PR TITLE
Require Redis 5.0 or later

### DIFF
--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -6,8 +6,8 @@ namespace Flownative\RedisSentinel;
 /*
  * This file is part of the Flownative.RedisSentinel package.
  *
- * Copyright (c) 2019 Robert Lemke, Flownative GmbH
- * Copyright (c) 2015 Neos project contributors
+ * Copyright (c) Robert Lemke, Flownative GmbH
+ * Copyright (c) Neos project contributors
  *
  * This package is Open Source Software. For the full copyright and license
  * information, please view the LICENSE file which was distributed with this

--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -31,7 +31,7 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
 {
     use RequireOnceFromValueTrait;
 
-    public const MIN_REDIS_VERSION = '2.8.0';
+    public const MIN_REDIS_VERSION = '5.0.0';
 
     protected Predis\Client $client;
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Robert Lemke, Flownative GmbH
-Copyright (c) 2015 Neos project contributors
+Copyright (c) Robert Lemke, Flownative GmbH
+Copyright (c) Neos project contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Tests/BaseTestCase.php
+++ b/Tests/BaseTestCase.php
@@ -4,8 +4,8 @@ namespace Flownative\RedisSentinel\Tests;
 /*
  * This file is part of the Flownative.RedisSentinel package.
  *
- * Copyright (c) 2019 Robert Lemke, Flownative GmbH
- * Copyright (c) 2015 Neos project contributors
+ * Copyright (c) Robert Lemke, Flownative GmbH
+ * Copyright (c) Neos project contributors
  *
  * This package is Open Source Software. For the full copyright and license
  * information, please view the LICENSE file which was distributed with this


### PR DESCRIPTION
Redis 5 was released in November 2017, so it should be plausible to raise the required version from 2.8 to 5.0.