### PR TITLE
Upgrade to predis/predis 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "neos/cache": "> 6.3 || 7.*",
         "neos/cache": "6.* || 7.* || 8.*",
         "ext-zlib": "*",
-        "predis/predis": "^1.1",
+        "predis/predis": "^2.0",
         "php": "7.4.* || 8.0.* || 8.1.*"
     },
     "require-dev": {


### PR DESCRIPTION
According to automatic and some first manual tests, upgrading from predis 1.1 to 2.0 apparently don't require code modifications on our side.