### PR TITLE
BUGFIX: Do not throw exceptions when `null` or `""` are used in `sentinels` setting

### DIFF
--- a/Classes/RedisBackend.php
+++ b/Classes/RedisBackend.php
@@ -435,12 +435,18 @@ class RedisBackend extends IndependentAbstractBackend implements TaggableBackend
      * If at least one Sentinel server is specified, this client operates in Sentinel mode
      * and ignores "hostname" and "port".
      *
-     * @param array|string $sentinels Sentinel server addresses, eg. ['tcp://10.101.213.145:26379', 'tcp://…'], or string with comma separated addresses
+     * @param array|string|null $sentinels Sentinel server addresses, eg. ['tcp://10.101.213.145:26379', 'tcp://…'], or string with comma separated addresses
      */
     public function setSentinels($sentinels): void
     {
-        if (is_string($sentinels)) {
-            $this->sentinels = explode(',', $sentinels);
+        if (is_null($sentinels)) {
+            $this->sentinels = [];
+        } elseif (is_string($sentinels)) {
+            if ($sentinels === '') {
+                $this->sentinels = [];
+            } else {
+                $this->sentinels = explode(',', $sentinels);
+            }
         } elseif (is_array($sentinels)) {
             $this->sentinels = $sentinels;
         } else {


### PR DESCRIPTION
If the sentinel setting exists it currently is always treated as a string or array containing sentinels which causes errors if a setting overwritten in via env-var or unset by another settings.yaml.

This change adds support for null and empty string as allowed value for the key `sentinels`, those values will yield an empty sentinels array and thus disable the use of sentinels.